### PR TITLE
Add more features to colormaps

### DIFF
--- a/hdc/colors/utils.py
+++ b/hdc/colors/utils.py
@@ -2,9 +2,9 @@
 
 from itertools import chain, tee
 from pathlib import Path
-from typing import Iterable, Optional, Union
+from typing import Iterable, Optional, Sequence, Union
 
-from .types import NodataType, RGBATuple, RGBTuple
+from .types import NodataType, RGBATuple, RGBTuple, SomeNumber
 
 INF = float("INF")
 
@@ -32,6 +32,17 @@ def hex_to_rgb(
     if len(a):
         return r, g, b, a[0]
     return (r, g, b)
+
+
+def rgb_to_hex(c: Sequence[SomeNumber], normalize: bool = False) -> str:
+    """convert RGB tuple to HEX string"""
+    assert len(c) in (3, 4)
+    if normalize:
+        c = [int(x * 255) for x in c]
+    else:
+        c = [int(x) for x in c]
+
+    return "#" + "".join(f"{x:02x}" for x in c)
 
 
 def create_color_table(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from hdc.colors._classes import HDCDiscreteRamp
-from hdc.colors.utils import create_color_table, hex_to_rgb, lagiter
+from hdc.colors.utils import create_color_table, hex_to_rgb, rgb_to_hex, lagiter
 
 
 @pytest.fixture
@@ -53,6 +53,7 @@ def test_lagiter():
 )
 def test_hex_to_rgb(hex_val, rgb_val, norm):
     assert hex_to_rgb(hex_val, norm) == rgb_val
+    assert rgb_to_hex(rgb_val, norm) == hex_val
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Methods to create "compatible" color ramps from a set of color-ramps. The idea is to retain the same colorization for input data, but use more bins with duplicate colors:

<img width="363" alt="Screenshot 2024-02-13 at 9 05 52 pm" src="https://github.com/WFP-VAM/hdc-colors/assets/1428024/0b6ecfc8-f3ce-4c06-af9f-db24b5ef9663">

That way we CAN perform palette substitution and safe disk by quantizing pixels into "unified palette bins". 