### PR TITLE
Optional `matplotlib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ pip install --extra-index-url=https://data.earthobservation.vam.wfp.org/pypi/ hd
 
 ```
 
-> **Note**
->
->The main purpose of this repo is to contain the color source, keeping the dependencies minimal. To install all dependencies that might be required for users, please use extras install `hdc-colors[all]`.
+> [!IMPORTANT]
+> The main purpose of this repo is to contain the color source, keeping the dependencies minimal. To install all dependencies that might be required for users, please use extras install `hdc-colors[all]`.
 
 ### Available color ramps
 To see a table with all available color ramps, check out the [rendered markdown](color_ramps.md)!  
@@ -45,6 +44,9 @@ hdc-colors-table rainfall -f rxs
 </div>
 
 ### Usage example
+
+> [!NOTE]
+> To run this example, you need the `matplotlib` package installed (comes with `hdc-colors[all]`)
 
 ```python
 import matplotib.pyplot as plt

--- a/hdc/colors/_classes.py
+++ b/hdc/colors/_classes.py
@@ -49,7 +49,12 @@ class HDCBaseClass:
     def cmap(self) -> "matplotlib.colors.ListedColormap":
         """ramp colors as matplotlib listed colormap"""
         # pylint: disable=import-outside-toplevel
-        from matplotlib.colors import ListedColormap
+        try:
+            from matplotlib.colors import ListedColormap
+        except ImportError as ie:
+            raise ImportError(
+                "matplotlib is required for using the `.cmap` property"
+            ) from ie
 
         return ListedColormap([hex_to_rgb(x, True) for x in self.cols], "")
 

--- a/hdc/colors/_version.py
+++ b/hdc/colors/_version.py
@@ -1,3 +1,3 @@
 """hdc-colors version"""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,16 @@
-matplotlib
+click==8.1.7
+contourpy==1.2.1
+cycler==0.12.1
+fonttools==4.53.1
+kiwisolver==1.4.5
+markdown-it-py==3.0.0
+matplotlib==3.9.2
+mdurl==0.1.2
+numpy==2.0.1
+packaging==24.1
+pillow==10.4.0
+Pygments==2.18.0
+pyparsing==3.1.2
+python-dateutil==2.9.0.post0
+rich==13.7.1
+six==1.16.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ include_package_data = false
 zip_safe = false
 packages = find_namespace:
 install_requires =
-  matplotlib
   numpy
 
 [options.extras_require]
@@ -45,8 +44,12 @@ ui =
   rich
   click>=1.8.6
 
+mpl = 
+  matplotlib
+
 all =
     %(ui)s
+    %(mpl)s
 
 [options.packages.find]
 include =


### PR DESCRIPTION
Make the `matplotlib` requirement optional as it's only used for one property, and brings along a lot of dependencies.

The `matplotlib` requirement can be installed with the `extras_require`:

- `hdc-colors[mpl]`
- `hdc-colors[all]`

